### PR TITLE
Upgrade GitHub Actions actions.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,22 +22,17 @@ jobs:
       STRIPE_TEST_PUBLISHABLE_KEY: 'pk_test_asecrettoeverybody'
     steps:
       - name: Get the code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           fetch-depth: 1
 
-      - name: Cache Python packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: pip-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
-
-
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.9'
           architecture: 'x64'
+          cache: 'pip'
+          cache-dependency-path: 'requirements*.txt'
 
       - name: Install packages
         run: |


### PR DESCRIPTION
Use the new versions of the checkout and setup-python actions, and the caching [now built-in to setup-python](https://github.com/actions/setup-python#caching-packages-dependencies).